### PR TITLE
Fix for nodejs 6.10 EOL in AWS Lambda

### DIFF
--- a/cloudformation/cf.json
+++ b/cloudformation/cf.json
@@ -74,7 +74,7 @@
         "FunctionName" : "list",
         "Handler" : "list.list",
         "Role" : { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-        "Runtime" : "nodejs6.10"
+        "Runtime" : "nodejs8.10"
       },
       "DependsOn" : ["LambdaExecutionRole"]
     },
@@ -89,7 +89,7 @@
         "FunctionName" : "get",
         "Handler" : "get.get",
         "Role" : { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-        "Runtime" : "nodejs6.10"
+        "Runtime" : "nodejs8.10"
       },
       "DependsOn" : ["LambdaExecutionRole"]
     },


### PR DESCRIPTION
Fixing the deprecation of nodejs 6.10 by upgrading runtime to 8.10

See AWS Support Policy: https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html