### PR TITLE
Updated lambda runtime to nodejs-12.x

### DIFF
--- a/cloudformation/cf.json
+++ b/cloudformation/cf.json
@@ -74,7 +74,7 @@
         "FunctionName" : "list",
         "Handler" : "list.list",
         "Role" : { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-        "Runtime" : "nodejs8.10"
+        "Runtime" : "nodejs12.x"
       },
       "DependsOn" : ["LambdaExecutionRole"]
     },
@@ -89,7 +89,7 @@
         "FunctionName" : "get",
         "Handler" : "get.get",
         "Role" : { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
-        "Runtime" : "nodejs8.10"
+        "Runtime" : "nodejs12.x"
       },
       "DependsOn" : ["LambdaExecutionRole"]
     },


### PR DESCRIPTION
Lambda deprecated 8.10 runtime, upgraded the runtime nodejs-12.x. Tested the changes during the lab "Deploying a Scalable Serverless API with AWS CloudFormation".